### PR TITLE
fix: ogg、opus 音频后缀支持

### DIFF
--- a/lib/util/file_utils.dart
+++ b/lib/util/file_utils.dart
@@ -47,7 +47,8 @@ class FileUtils {
       case "midi":
       case "realaudio":
       case "vqf":
-      case "oggvorbis":
+      case "ogg":
+      case "opus":
       case "flac":
       case "aac":
         return FileType.audio;


### PR DESCRIPTION
ogg 和 opus 音频的后缀支持，原先的 oggvorbis 后缀是错误的。